### PR TITLE
Removed tor.abhl.org

### DIFF
--- a/DNS-Blacklist-Monitor/src/SpamBlackListMonitor.groovy
+++ b/DNS-Blacklist-Monitor/src/SpamBlackListMonitor.groovy
@@ -175,7 +175,6 @@ def dnsRblProviderList = [
         'spamlist.or.kr',
         'spamrbl.imp.ch',
         't3direct.dnsbl.net.au',
-        'tor.ahbl.org',
         'tor.dnsbl.sectoor.de',
         'torserver.tor.dnsbl.sectoor.de',
         'ubl.lashback.com',


### PR DESCRIPTION
- Server lookup service went out of service, see http://ahbl.org/
